### PR TITLE
Fix field rprof out of bounds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,6 +185,7 @@ all:
 	@echo "***********************************"
 
 install:
+	mkdir bin
 	(cd misc;	make -k all)
 	(cd tslib;	make -k all)
 	(cd Bellhop;	make -k install)
@@ -198,7 +199,7 @@ install:
 	@echo "***************************************"
 
 clean:
-	-rm -f bin/*.exe
+	-rm -rf bin
 	find . -name '*.dSYM' -exec rm -r {} +
 	find . -name '*.png'  -exec rm -r {} +
 	find . -name '*.eps'  -exec rm -r {} +

--- a/Makefile
+++ b/Makefile
@@ -217,3 +217,4 @@ clean:
 	(cd Scooter;	make -k -i clean)
 	(cd tests;	make -k -i clean)
 
+


### PR DESCRIPTION
  ## Problem

  `EvaluateAD` and `EvaluateCM` (KrakenField) declare their `rProf` dummy
  argument as `rProf( NProf + 1 )` and use the extra element as a range
  sentinel — `EvaluateADMod.f90` writes `rProf( NProf + 1 ) = 1e20`, and
  `EvaluateCMMod.f90` reads `RProf( iProf + 1 )` in its segment-advance
  loop guards (Fortran does not guarantee short-circuit `.AND.`, so the
  `iProf < NProf` test does not prevent the access).

  However, `ReadVector` (`misc/SourceReceiverPositions.f90`) only
  allocates `MAX( 3, NProf )` elements. Any coupled-mode or adiabatic
  run with **three or more profiles** therefore passes an array one
  element too small — a heap out-of-bounds write in the adiabatic path
  and an out-of-bounds read in the coupled-mode path. `NProf = 1` or `2`
  are accidentally safe because of the `MAX( 3, ... )` padding, which is
  why range-independent tests never catch it.

  Reproducible with `gfortran -fcheck=bounds` on any `.flp` with
  `NProf >= 3`. The slot is semantically required — `EvaluateCMMod.f90`
  even carries the commented-out assignment
  `!RProf( NProf + 1 ) = HUGE( RProf( NProf ) )`.

  ## Fix

  In `field.f90`, after `ReadVector` returns, reallocate `rProf` with
  `NProf + 1` elements and set the sentinel to `HUGE`. `EvaluateAD`
  overwrites the slot with its own `1e20` sentinel as before (now in
  bounds); in `EvaluateCM` the `HUGE` sentinel gives the intended
  "last profile extends to infinity" behaviour in the comparisons.

  No results change for runs that didn't already corrupt memory.

## Post-scriptum

This change wasn't made by me; I don't know how to code in Fortran. 
However, while working on uacpy—a Python module that provides an 
abstraction layer for your models—several of the LLMs I used flagged 
and confirmed this bug. I hope this is helpful to you.