### PR TITLE
FIELD: fix out-of-bounds access on rProf for NProf >= 3

### DIFF
--- a/KrakenField/field.f90
+++ b/KrakenField/field.f90
@@ -106,6 +106,18 @@ PROGRAM FIELD
   CALL ReadVector( NProf, RProf, 'Profile ranges, RProf', 'km' )
   RProf = RProf / 1000.0   ! convert m back to km (undoing what ReadVector did)
 
+  ! EvaluateAD and EvaluateCM declare their rProf dummy as rProf( NProf + 1 )
+  ! and use the extra element as a range sentinel (EvaluateAD writes it).
+  ! ReadVector only allocates MAX( 3, NProf ) elements, so for NProf >= 3 the
+  ! actual argument is one element too small; extend it and set the sentinel.
+  BLOCK
+    REAL (KIND=8), ALLOCATABLE :: rProfTmp( : )
+    ALLOCATE( rProfTmp( NProf + 1 ) )
+    rProfTmp( 1 : NProf ) = rProf( 1 : NProf )
+    rProfTmp( NProf + 1 ) = HUGE( rProf( 1 ) )
+    CALL MOVE_ALLOC( rProfTmp, rProf )
+  END BLOCK
+
   IF ( NProf == 1      ) THEN
      WRITE( PRTFile, * ) 'Range-independent calculation'
   ELSE


### PR DESCRIPTION
  ## Problem

  `EvaluateAD` and `EvaluateCM` (KrakenField) declare their `rProf` dummy
  argument as `rProf( NProf + 1 )` and use the extra element as a range
  sentinel — `EvaluateADMod.f90` writes `rProf( NProf + 1 ) = 1e20`, and
  `EvaluateCMMod.f90` reads `RProf( iProf + 1 )` in its segment-advance
  loop guards (Fortran does not guarantee short-circuit `.AND.`, so the
  `iProf < NProf` test does not prevent the access).

  However, `ReadVector` (`misc/SourceReceiverPositions.f90`) only
  allocates `MAX( 3, NProf )` elements. Any coupled-mode or adiabatic
  run with **three or more profiles** therefore passes an array one
  element too small — a heap out-of-bounds write in the adiabatic path
  and an out-of-bounds read in the coupled-mode path. `NProf = 1` or `2`
  are accidentally safe because of the `MAX( 3, ... )` padding, which is
  why range-independent tests never catch it.

  Reproducible with `gfortran -fcheck=bounds` on any `.flp` with
  `NProf >= 3`. The slot is semantically required — `EvaluateCMMod.f90`
  even carries the commented-out assignment
  `!RProf( NProf + 1 ) = HUGE( RProf( NProf ) )`.

  ## Fix

  In `field.f90`, after `ReadVector` returns, reallocate `rProf` with
  `NProf + 1` elements and set the sentinel to `HUGE`. `EvaluateAD`
  overwrites the slot with its own `1e20` sentinel as before (now in
  bounds); in `EvaluateCM` the `HUGE` sentinel gives the intended
  "last profile extends to infinity" behaviour in the comparisons.

  No results change for runs that didn't already corrupt memory.

## Post-scriptum

This change wasn't made by me; I don't know how to code in Fortran. 
However, while working on uacpy—a Python module that provides an 
abstraction layer for your models—several of the LLMs I used flagged 
and confirmed this bug. I hope this is helpful to you.